### PR TITLE
Fix pr-build error caused by lxml

### DIFF
--- a/open-machine-learning-jupyter-book/environment.yml
+++ b/open-machine-learning-jupyter-book/environment.yml
@@ -10,6 +10,7 @@ dependencies:
     - pandas==1.5.2
     - numpy==1.24.1
     - jsonschema==2.6.0
+    - lxml[html_clean]
     - matplotlib==3.6.2
     - pywaffle==1.1.0
     - scikit-learn==1.2.0


### PR DESCRIPTION
Fix pr-build error by adding lxml[html_clean] dependency in environment.yml

Build error: 
![image](https://github.com/ocademy-ai/machine-learning/assets/99715727/f89e977a-31de-4a0a-838a-b7d555bb9573)

Caused by:
![image](https://github.com/ocademy-ai/machine-learning/assets/99715727/ae28d2fc-9935-4545-91e5-ae73c6eb8e95)
